### PR TITLE
Allow case control via SearchQueryGeneratorParameters

### DIFF
--- a/server/rocket_server.rs
+++ b/server/rocket_server.rs
@@ -269,6 +269,7 @@ fn search_from_query_params(database: String, params: QueryParams) -> Result<Sea
         search_term: params.query.to_string(),
         top: params.top,
         skip: params.skip,
+        ignore_case: None,
         operator: params.operator,
         levenshtein: params.levenshtein,
         levenshtein_auto_limit: params.levenshtein_auto_limit,

--- a/src/query_generator.rs
+++ b/src/query_generator.rs
@@ -53,6 +53,7 @@ pub struct SearchQueryGeneratorParameters {
 
     pub top: Option<usize>,
     pub skip: Option<usize>,
+    pub ignore_case: Option<bool>,
     pub operator: Option<String>,
     pub levenshtein: Option<usize>, // TODO, it's called levenshtein here, but levenshtein_distance in the request.
 

--- a/src/query_generator/query_parser_to_veloci_request.rs
+++ b/src/query_generator/query_parser_to_veloci_request.rs
@@ -69,6 +69,7 @@ fn query_ast_to_request<'a>(ast: &UserAST, opt: &SearchQueryGeneratorParameters,
                 terms: vec![term],
                 starts_with,
                 is_regex,
+                ignore_case: opt.ignore_case,
                 ..Default::default()
             };
             SearchRequest::Search(part)

--- a/tests/all/test_code_search.rs
+++ b/tests/all/test_code_search.rs
@@ -81,13 +81,24 @@ fn pattern_code_search_query_generator() {
 }
 
 #[test]
-fn pattern_code_search_allows_ignore_case_query_generator() {
+fn pattern_code_search_ignore_case_query_generator() {
     let mut params = query_generator::SearchQueryGeneratorParameters::default();
     params.search_term = "*myfun*type1*".to_string();
 
     let hits = search_testo_to_doco_qp!(params).data;
     assert_eq!(hits.len(), 1);
     assert_eq!(hits[0].doc["line"], "function myfun(param1: Type1)");
+}
+
+#[test]
+fn pattern_code_search_case_sensitive_query_generator() {
+    let mut params = query_generator::SearchQueryGeneratorParameters::default();
+    params.search_term = "*myfun*type1*".to_string();
+    params.ignore_case = Some(false);
+
+    let hits = search_testo_to_doco_qp!(params).data;
+    assert_eq!(hits.len(), 0);
+    // assert_eq!(hits[0].doc["line"], "function myfun(param1: Type1)");
 }
 
 #[test]


### PR DESCRIPTION
This PR will add the attribute ignore_case to the SearchQueryGeneratorParameters. 